### PR TITLE
fix: replace obsolete getCachedPlayers call

### DIFF
--- a/src/main/java/com/NameChangeDetector/NameChangeDetectorPlugin.java
+++ b/src/main/java/com/NameChangeDetector/NameChangeDetectorPlugin.java
@@ -99,9 +99,9 @@ public class NameChangeDetectorPlugin extends Plugin
 		if ((action == MenuAction.RUNELITE || action == MenuAction.RUNELITE_PLAYER) && option.equals(INVESTIGATE)) {
 			final String target;
 			if (action == MenuAction.RUNELITE_PLAYER) {
-				// The player id is included in the event, so we can use that to get the player name,
+				// The player is included in the event, so we can use that to get the player name,
 				// which avoids having to parse out the combat level and any icons preceding the name.
-				Player player = client.getCachedPlayers()[event.getId()];
+				Player player = event.getMenuEntry().getPlayer();
 				if (player != null) {
 					target = player.getName();
 				} else {


### PR DESCRIPTION
```
> Task :compileJava
/tmp/pluginhub-package11082602222547477078/name-change-detector/repo/src/main/java/com/NameChangeDetector/NameChangeDetectorPlugin.java:104: error: cannot find symbol
				Player player = client.getCachedPlayers()[event.getId()];
				                      ^
  symbol:   method getCachedPlayers()
  location: variable client of type Client
Note: /tmp/pluginhub-package11082602222547477078/name-change-detector/repo/src/main/java/com/NameChangeDetector/NameChangeDetectorPlugin.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 error
```